### PR TITLE
Fix BankFactory().auto_create() error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ def go_to_gateway_view(request):
 
     factory = bankfactories.BankFactory()
     try:
-        bank = factory.auto_create() # or factory.create(bank_models.BankType.BMI) or set identifier
+        bank = factory.auto_create(request) # or factory.create(request, bank_models.BankType.BMI) or set identifier
         bank.set_request(request)
         bank.set_amount(amount)
         # یو آر ال بازگشت به نرم افزار برای ادامه فرآیند
@@ -281,7 +281,9 @@ bank_models.Bank.objects.update_expire_records()
 
 # مشخص کردن رکوردهایی که باید تعیین وضعیت شوند
 for item in bank_models.Bank.objects.filter_return_from_bank():
-	bank = factory.create(bank_type=item.bank_type, identifier=item.bank_choose_identifier)
+	bank = factory.create(request=request, 
+			      bank_type=item.bank_type, 
+			      identifier=item.bank_choose_identifier)
 	bank.verify(item.tracking_code)		
 	bank_record = bank_models.Bank.objects.get(tracking_code=item.tracking_code)
 	if bank_record.is_success:

--- a/azbankgateways/default_settings.py
+++ b/azbankgateways/default_settings.py
@@ -24,6 +24,7 @@ BANK_CLASS = getattr(
         "ZIBAL": "azbankgateways.banks.Zibal",
         "BAHAMTA": "azbankgateways.banks.Bahamta",
         "MELLAT": "azbankgateways.banks.Mellat",
+	"PAYV1": "azbankgateways.banks.PayV1",
     },
 )
 _AZ_IRANIAN_BANK_GATEWAYS = getattr(settings, "AZ_IRANIAN_BANK_GATEWAYS", {})

--- a/azbankgateways/views/banks.py
+++ b/azbankgateways/views/banks.py
@@ -19,7 +19,7 @@ def callback_view(request):
         raise Http404
 
     factory = BankFactory()
-    bank = factory.create(bank_type, identifier=identifier)
+    bank = factory.create(request, bank_type, identifier=identifier)
     try:
         bank.verify_from_gateway(request)
     except AZBankGatewaysException:

--- a/azbankgateways/views/samples.py
+++ b/azbankgateways/views/samples.py
@@ -24,8 +24,7 @@ def sample_payment_view(request):
             mobile_number = form.cleaned_data["mobile_number"]
             factory = bankfactories.BankFactory()
             try:
-                bank = factory.auto_create()
-                bank.set_request(request)
+                bank = factory.auto_create(request=request)
                 bank.set_amount(amount)
                 # یو آر ال بازگشت به نرم افزار برای ادامه فرآیند
                 bank.set_client_callback_url(reverse(f"{AZIranianBankGatewaysConfig.name}:sample-result"))


### PR DESCRIPTION
I was trying to use auto_create() with zibal, using sample-payment, when i noticed it raises an exception, which then took me to check_gateway(), which then again took me to _get_gateway_callback_url(). After plyaing a little with it, i realized it isn't sending the absolute url as callbackUrl to the bank, which then in return raises an error. So, in order to have the absolute url we're gonna need to have the request while creating the bank.