### PR TITLE
Resolved the incorrect gateway currency settings in Zarinpal

### DIFF
--- a/azbankgateways/banks/zarinpal.py
+++ b/azbankgateways/banks/zarinpal.py
@@ -64,7 +64,7 @@ class Zarinpal(BaseBank):
             "description": description,
             "merchant_id": self._merchant_code,
             "amount": self.get_gateway_amount(),
-            "currency": self._currency,
+            "currency": self.get_gateway_currency(),
             "metadata": {},
             "callback_url": self._get_gateway_callback_url(),
         }


### PR DESCRIPTION
When using self._currency in the get_pay_data method, everything functions correctly if the currency configured in settings.py is set to IRT. However, if the currency is set to IRR in settings.py, the price is divided by 10 twice: once by CurrencyEnum.rial_to_toman and again by the payment gateway.
I have fixed this issue by using self.get_gateway_currency instead.