### PR TITLE
Allow custom gateway url callback for zarinpal [optional]

### DIFF
--- a/azbankgateways/banks/banks.py
+++ b/azbankgateways/banks/banks.py
@@ -36,6 +36,7 @@ class BaseBank:
     _reference_number: str = ""
     _transaction_status_text: str = ""
     _client_callback_url: str = ""
+    _custom_callback_url: str = ""
     _bank: Bank = None
     _request = None
 
@@ -154,6 +155,10 @@ class BaseBank:
             self._bank.callback_url,
             {settings.TRACKING_CODE_QUERY_PARAM: self.get_tracking_code()},
         )
+    
+    def get_custom_callback_url(self):
+        """این متد برای گرفتن کال بک درگاه استفاده می شود."""
+        return self._custom_callback_url
 
     def redirect_client_callback(self):
         """ "این متد کاربر را به مسیری که نرم افزار میخواهد هدایت خواهد کرد و پس از وریفای شدن استفاده می شود."""
@@ -179,6 +184,23 @@ class BaseBank:
         افزار."""
         if not self._bank:
             self._client_callback_url = callback_url
+        else:
+            logging.critical(
+                "You are change the call back url in invalid situation.",
+                extra={
+                    "bank_id": self._bank.pk,
+                    "status": self._bank.status,
+                },
+            )
+            raise BankGatewayStateInvalid(
+                "Bank state not equal to waiting. Probably finish "
+                f"or redirect to bank gateway. status is {self._bank.status}"
+            )
+        
+    def set_custom_callback_url(self, callback_url):
+        """این متد برای تنظیم کردن کال بک درگاه به صورت دستی استفاده می شود."""
+        if not self._bank:
+            self._custom_callback_url = callback_url
         else:
             logging.critical(
                 "You are change the call back url in invalid situation.",

--- a/azbankgateways/banks/zarinpal.py
+++ b/azbankgateways/banks/zarinpal.py
@@ -60,14 +60,17 @@ class Zarinpal(BaseBank):
     def get_pay_data(self):
         description = "خرید با شماره پیگیری - {}".format(self.get_tracking_code())
 
+        callback_url = self.get_custom_callback_url() or self._get_gateway_callback_url()
+
         data = {
             "description": description,
             "merchant_id": self._merchant_code,
             "amount": self.get_gateway_amount(),
             "currency": self.get_gateway_currency(),
             "metadata": {},
-            "callback_url": self._get_gateway_callback_url(),
+            "callback_url": callback_url,
         }
+        
         mobile_number = self.get_mobile_number()
         if mobile_number:
             data["metadata"].update({"mobile": mobile_number})


### PR DESCRIPTION
سلام و وقت بخیر
درگاه پرداخت زرین پال به تازگی فول دومین وبسایت هارو اعم از ساب دومین ها و مسیر ها بررسی میکنه و اگه کال بک ست شده دقیقا مشابه دومین ثبت شده نباشه ارور میده 
تیم ما برای پروژه های مرتبط و مختلف گاها از یک درگاه پرداخت مشترک استفاده میکنه که بخاطر تغییرات اخیر باعث به وجود اومدن ارور میشه 
من دو متود رو برای ست کردن و گرفتن کال بک یو ار ال از کاربر (self, callback_url)set_custom_callback_url  به این شکل در BaseBank اضافه کردم و داخل متود get_pay_data(self) مقدار کلید callback_url در data  رو callback_url = self.get_custom_callback_url() or self._get_gateway_callback_url() قرار دادم تا توسعه دهندگان در صورت نیاز بتونن کال بک خودشون رو بجای کال بک دیفالت get_gateway_callback_url استفاده کنن
